### PR TITLE
Add backward pass split heuristics (optional)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ build-backend = "setuptools.build_meta"
 dependency_links = ["https://pypi.taichi.graphics/simple/"]
 
 [project.scripts]  # Optional
-fit_image_gaussians = "taichi_splatting.scripts.fit_image_gaussians:main"
+fit_image_gaussians = "taichi_splatting.examples.fit_image_gaussians:main"
 bench_projection = "taichi_splatting.benchmarks.bench_projection:main"
 bench_rasterizer = "taichi_splatting.benchmarks.bench_rasterizer:main"
 bench_tilemapper = "taichi_splatting.benchmarks.bench_tilemapper:main"

--- a/taichi_splatting/benchmarks/bench_rasterizer.py
+++ b/taichi_splatting/benchmarks/bench_rasterizer.py
@@ -80,14 +80,14 @@ def bench_rasterizer(args):
   benchmarked('backward (all)', backward, profile=args.profile, iters=args.iters)  
 
   
-  def compute_weight():
+  def compute_split_heuristics():
     raster = rasterize_with_tiles(gaussians2d=gaussians2d, features=gaussians.feature, 
       tile_overlap_ranges=tile_ranges.view(-1, 2), overlap_to_point=overlap_to_point,
-      image_size=args.image_size, config=config, compute_weight=True)
+      image_size=args.image_size, config=config, compute_split_heuristics=True)
     
     raster.image.sum().backward()
 
-  benchmarked('backward (compute_weight)', compute_weight, profile=args.profile, iters=args.iters)  
+  benchmarked('backward (compute_split_heuristics)', compute_split_heuristics, profile=args.profile, iters=args.iters)  
 
 
 def main():

--- a/taichi_splatting/examples/fit_image_gaussians.py
+++ b/taichi_splatting/examples/fit_image_gaussians.py
@@ -126,7 +126,7 @@ def main():
 
   gaussians = random_2d_gaussians(cmd_args.n, (w, h), scale_factor=0.1).to(torch.device('cuda:0'))
   learning_rates = dict(
-    position=0.2,
+    position=0.1,
     log_scaling=0.05,
     rotation=0.005,
     alpha_logit=0.1,

--- a/taichi_splatting/examples/fit_image_gaussians.py
+++ b/taichi_splatting/examples/fit_image_gaussians.py
@@ -30,10 +30,8 @@ def parse_args():
 
   parser.add_argument('--n', type=int, default=1000)
   parser.add_argument('--target', type=int, default=None)
-  parser.add_argument('--max_epoch', type=int, default=1000)
-
-  parser.add_argument('--split_rate', type=float, default=0.25, help='Rate of points to split each epoch (proportional to number of points)')
-  parser.add_argument('--split_reduction', type=float, default=0.95, help='When points is near target, reduce split rate by this factor each epoch')
+  parser.add_argument('--max_epoch', type=int, default=200)
+  parser.add_argument('--split_rate', type=float, default=0.1, help='Rate of points to split each epoch (proportional to number of points)')
 
   parser.add_argument('--write_frames', type=Path, default=None)
 
@@ -189,10 +187,12 @@ def main():
                               a_min=0.25, a_max=4)
         
         if min(split_ratio, 1/split_ratio) > 0.98:
-          split_rate *= cmd_args.split_reduction
+          factor = math.pow(split_rate, 1/(cmd_args.max_epoch - epoch))
+
+          split_rate *= factor
 
 
-        grad_thresh = torch.quantile(gradient, 1 - (split_rate * split_ratio) )
+        grad_thresh = torch.quantile(gradient, 1 - (split_rate * split_ratio))
         vis_thresh = torch.quantile(visibility, split_rate * 1/split_ratio )
 
     

--- a/taichi_splatting/examples/fit_image_gaussians.py
+++ b/taichi_splatting/examples/fit_image_gaussians.py
@@ -29,7 +29,7 @@ def parse_args():
   parser.add_argument('--n', type=int, default=1000)
   parser.add_argument('--target', type=int, default=None)
 
-  parser.add_argument('--split_rate', type=float, default=0.4)
+  parser.add_argument('--split_rate', type=float, default=0.2)
 
   parser.add_argument('--debug', action='store_true')
   parser.add_argument('--show', action='store_true')
@@ -86,12 +86,15 @@ def train_epoch(opt, gaussians, ref_image, epoch_size=100, config:RasterConfig =
       loss.backward()
 
 
-      contrib += raster.point_weight
       check_finite(gaussians)
       opt.step()
 
       with torch.no_grad():
         gaussians.log_scaling.clamp_(min=-1, max=4)
+
+        contrib =  raster.point_weight if i == 0 \
+            else (1 - grad_alpha) * contrib + grad_alpha * raster.point_weight
+
 
       visibility, gradient = contrib.unbind(dim=1)
     return raster.image, visibility, gradient 

--- a/taichi_splatting/examples/fit_image_gaussians.py
+++ b/taichi_splatting/examples/fit_image_gaussians.py
@@ -29,7 +29,7 @@ def parse_args():
   parser.add_argument('--n', type=int, default=1000)
   parser.add_argument('--target', type=int, default=None)
 
-  parser.add_argument('--split_rate', type=float, default=0.2)
+  parser.add_argument('--split_rate', type=float, default=0.4)
 
   parser.add_argument('--debug', action='store_true')
   parser.add_argument('--show', action='store_true')

--- a/taichi_splatting/examples/fit_image_gaussians.py
+++ b/taichi_splatting/examples/fit_image_gaussians.py
@@ -29,7 +29,7 @@ def parse_args():
   parser.add_argument('--n', type=int, default=1000)
   parser.add_argument('--target', type=int, default=None)
 
-  parser.add_argument('--split_rate', type=float, default=0.4)
+  parser.add_argument('--split_rate', type=float, default=0.5)
 
   parser.add_argument('--debug', action='store_true')
   parser.add_argument('--show', action='store_true')

--- a/taichi_splatting/examples/fit_image_gaussians.py
+++ b/taichi_splatting/examples/fit_image_gaussians.py
@@ -72,7 +72,7 @@ def train_epoch(opt, gaussians, ref_image, epoch_size=100, config:RasterConfig =
         features=gaussians.feature, 
         image_size=(w, h), 
         config=config,
-        compute_weight=True)
+        compute_split_heuristics=True)
 
       loss = torch.nn.functional.l1_loss(raster.image, ref_image) #+ (1e-4 * gaussians.log_scaling).pow(2).sum()
       loss.backward()
@@ -83,8 +83,8 @@ def train_epoch(opt, gaussians, ref_image, epoch_size=100, config:RasterConfig =
       with torch.no_grad():
         gaussians.log_scaling.clamp_(min=-1, max=4)
 
-        contrib =  raster.point_weight if i == 0 \
-            else (1 - grad_alpha) * contrib + grad_alpha * raster.point_weight
+        contrib =  raster.point_split_heuristics if i == 0 \
+            else (1 - grad_alpha) * contrib + grad_alpha * raster.point_split_heuristics
 
 
       visibility, gradient = contrib.unbind(dim=1)
@@ -161,7 +161,7 @@ def main():
       if cmd_args.show:
         gaussians2d = project_gaussians2d(params)
         depths = encode_depth32(params.depth)
-        raster =  rasterize(gaussians2d, depths, gradient.contiguous().unsqueeze(-1), image_size=(w, h), config=config, compute_weight=True)
+        raster =  rasterize(gaussians2d, depths, gradient.contiguous().unsqueeze(-1), image_size=(w, h), config=config, compute_split_heuristics=True)
 
         err = torch.abs(ref_image - image)
         

--- a/taichi_splatting/examples/fit_image_gaussians.py
+++ b/taichi_splatting/examples/fit_image_gaussians.py
@@ -29,13 +29,13 @@ def parse_args():
   parser.add_argument('--n', type=int, default=1000)
   parser.add_argument('--target', type=int, default=None)
 
-  parser.add_argument('--split_rate', type=float, default=0.01)
+  parser.add_argument('--split_rate', type=float, default=0.2)
 
   parser.add_argument('--debug', action='store_true')
   parser.add_argument('--show', action='store_true')
 
   parser.add_argument('--profile', action='store_true')
-  parser.add_argument('--epoch', type=int, default=100, help='Number of iterations per measurement/profiling')
+  parser.add_argument('--epoch', type=int, default=20, help='Number of iterations per measurement/profiling')
   
   return parser.parse_args()
 
@@ -185,7 +185,7 @@ def main():
 
         split_ratio = np.clip(cmd_args.target / gaussians.batch_size[0], 
                               a_min=0.5, a_max=2)
-        split_rate = cmd_args.split_rate
+        split_rate = cmd_args.split_rate / (0.1 * epoch + 1)
 
         grad_thresh = torch.quantile(gradient, 1 - (split_rate * split_ratio) )
         vis_thresh = torch.quantile(visibility, split_rate * 1/split_ratio )

--- a/taichi_splatting/examples/fit_image_gaussians.py
+++ b/taichi_splatting/examples/fit_image_gaussians.py
@@ -1,6 +1,7 @@
 import math
 import cv2
 import argparse
+import numpy as np
 import taichi as ti
 
 import torch
@@ -24,24 +25,28 @@ def parse_args():
   parser.add_argument('image_file', type=str)
   parser.add_argument('--seed', type=int, default=0)
   parser.add_argument('--tile_size', type=int, default=16)
-  parser.add_argument('--n', type=int, default=20000)
 
+  parser.add_argument('--n', type=int, default=1000)
+  parser.add_argument('--target', type=int, default=None)
+
+  parser.add_argument('--split_rate', type=float, default=0.01)
 
   parser.add_argument('--debug', action='store_true')
   parser.add_argument('--show', action='store_true')
-
-  parser.add_argument('--split', action='store_true', help="Enable splitting of gaussians")
-
-  parser.add_argument('--grad-threshold', type=float, default=2e-7)
-  parser.add_argument('--vis-threshold', type=float, default=4)
 
   parser.add_argument('--profile', action='store_true')
   parser.add_argument('--epoch', type=int, default=100, help='Number of iterations per measurement/profiling')
   
   return parser.parse_args()
 
+def sigmoid(x):
+  return 1 / (1 + math.exp(-x))
+
 def inverse_sigmoid(x):
   return math.log(x / (1 - x))
+
+def split_ratio(n, target):
+  return 1 / (1 + math.exp(-inverse_sigmoid(n / target)))
 
 
 def display_image(name, image):
@@ -114,6 +119,8 @@ def main():
   if cmd_args.show:
     cv2.namedWindow('rendered', cv2.WINDOW_NORMAL)
     cv2.namedWindow('gradient', cv2.WINDOW_NORMAL)
+    cv2.namedWindow('err', cv2.WINDOW_NORMAL)
+
 
     cv2.resizeWindow('rendered', w, h)
     cv2.resizeWindow('gradient', w, h)
@@ -135,7 +142,7 @@ def main():
   print(list(params.keys()))
 
   ref_image = torch.from_numpy(ref_image).to(dtype=torch.float32, device=device) / 255
-  config = RasterConfig(tile_size=cmd_args.tile_size, gaussian_scale=3.)
+  config = RasterConfig(tile_size=cmd_args.tile_size, gaussian_scale=3.0)
 
 
 
@@ -145,21 +152,17 @@ def main():
     torch.cuda.synchronize()
     end = time.time()
 
-    cpsnr = psnr(ref_image, image)
-    print(f'{cmd_args.epoch / (end - start):.1f} iters/sec CPSNR {cpsnr:.2f}')
-    return image, grad, vis
+    return image, grad, vis, end - start
 
 
-  train = with_benchmark(train_epoch) if cmd_args.profile else timed_epoch
+  train = with_benchmark(timed_epoch) if cmd_args.profile else timed_epoch
 
   epoch = 0
   while True:
-    epoch_size = int((cmd_args.epoch + 1) * (1 + 4 / (epoch + 1)))
+    epoch_size = cmd_args.epoch
 
-    image, gradient, visibility = train(params.optimizer, params, ref_image, 
+    image, gradient, visibility, epoch_time = train(params.optimizer, params, ref_image, 
                                         epoch_size=epoch_size, config=config)
-
-    grad_thresh =  cmd_args.grad_threshold
 
     with torch.no_grad():
 
@@ -168,29 +171,41 @@ def main():
         depths = encode_depth32(params.depth)
         raster =  rasterize(gaussians2d, depths, gradient.unsqueeze(-1), image_size=(w, h), config=config, compute_weight=True)
 
+        err = torch.abs(ref_image - image)
         
-        display_image('gradient', (0.5 * raster.image / grad_thresh ))
+        display_image('gradient', (0.5 * raster.image / raster.image.mean() ))
         display_image('rendered', image)
+        display_image('err',  0.25 * err / err.mean(dim=(0, 1), keepdim=True))
 
+      cpsnr = psnr(ref_image, image)
+      print(f'{epoch}: {epoch_size / epoch_time:.1f} iters/sec CPSNR {cpsnr:.2f}')
 
-      if cmd_args.split:
+      if cmd_args.target:
         gaussians = Gaussians2D(**params.tensors, batch_size=params.batch_size)
-        vis_threshold = cmd_args.epoch * cmd_args.vis_threshold 
 
+        split_ratio = np.clip(cmd_args.target / gaussians.batch_size[0], 
+                              a_min=0.5, a_max=2)
+        split_rate = cmd_args.split_rate
 
-        prune_mask = (visibility < vis_threshold) #& (gradient < grad_thresh)
+        grad_thresh = torch.quantile(gradient, 1 - (split_rate * split_ratio) )
+        vis_thresh = torch.quantile(visibility, split_rate * 1/split_ratio )
+
+    
+        prune_mask = (visibility <= vis_thresh)  & (gradient <  grad_thresh)
         split_mask = torch.zeros_like(prune_mask, dtype=torch.bool)
 
-        # split_mask = (gradient > grad_thresh) & (visibility > 2 * vis_threshold)
-        
-        # splits = split_gaussians2d(gaussians[split_mask], scaling=0.8)
+        split_mask = (gradient > grad_thresh) & (visibility > vis_thresh)
+        splits = split_gaussians2d(gaussians[split_mask], scaling=0.8)
 
-        # params = params[~(split_mask | transparent)]
-        # params = params.append_tensors(splits.to_tensordict())
-        params = params[~prune_mask]
-      
-        print(f"Split {split_mask.sum()}, pruned {prune_mask.sum()} total {params.batch_size} points") 
-        epoch += 1
+        params = params[~(split_mask | prune_mask)]
+        params = params.append_tensors(splits.to_tensordict())
+        # # # params = params[~prune_mask]
+
+        print(f" split {split_mask.sum()}, pruned {prune_mask.sum()} {params.batch_size} points")
+
+ 
+        
+      epoch += 1
 
 
 def with_benchmark(f):

--- a/taichi_splatting/misc/parameter_class.py
+++ b/taichi_splatting/misc/parameter_class.py
@@ -72,6 +72,11 @@ class ParameterClass():
     return self.tensors[name]
 
 
+  def to(self, device):
+    return ParameterClass(
+      self.tensors.to(device), self.optimizer.param_groups, self.get_state()
+    )
+
   def to_dict(self):
     return self.tensors.to_dict()
   

--- a/taichi_splatting/rasterizer/backward.py
+++ b/taichi_splatting/rasterizer/backward.py
@@ -200,7 +200,7 @@ def backward_kernel(config: RasterConfig,
 
               contribution += vec2(
                 ((feature_diff * weight)**2).sum(),
-                (alpha_grad_from_feature**2).sum()
+                (ti.abs(alpha_grad_from_feature)).sum()
               )
 
           if ti.simt.warp.any_nonzero(ti.u32(0xffffffff), ti.i32(has_grad)):

--- a/taichi_splatting/rasterizer/backward.py
+++ b/taichi_splatting/rasterizer/backward.py
@@ -185,7 +185,7 @@ def backward_kernel(config: RasterConfig,
               grad_feature += weight * grad_pixel_feature[i, :]
 
               feature_diff = (feature * T_i[i] - w_i[i, :] / (1. - alpha))
-              contribution = ti.abs(feature_diff).sum() * weight
+              contribution = ((feature_diff* weight)**2).sum() 
 
               if ti.static(points_requires_grad):
                 # \frac{dC}{da_i} = c_i T(i) - \frac{1}{1 - a_i} w_i

--- a/taichi_splatting/rasterizer/backward.py
+++ b/taichi_splatting/rasterizer/backward.py
@@ -156,8 +156,8 @@ def backward_kernel(config: RasterConfig,
         for in_group_idx in range(point_group_size):
           point_index = end_offset - (group_offset_base + in_group_idx)
 
-          if not ti.simt.warp.any_nonzero(ti.u32(0xffffffff), ti.i32(point_index <= last_point_thread)):
-            continue
+          # if not ti.simt.warp.any_nonzero(ti.u32(0xffffffff), ti.i32(point_index <= last_point_thread)):
+          #   continue
 
           # Could factor this out and only compute grad if needed
           # however, it does not seem to make any difference

--- a/taichi_splatting/rasterizer/backward.py
+++ b/taichi_splatting/rasterizer/backward.py
@@ -200,7 +200,8 @@ def backward_kernel(config: RasterConfig,
 
               contribution += vec2(
                 ((feature_diff * weight)**2).sum(),
-                ((alpha_grad_from_feature)**2).sum()
+                # ((alpha_grad_from_feature)**2).sum()
+                ti.abs(alpha_grad * point_alpha * dp_dmean).sum()
               )
 
           if ti.simt.warp.any_nonzero(ti.u32(0xffffffff), ti.i32(has_grad)):

--- a/taichi_splatting/rasterizer/backward.py
+++ b/taichi_splatting/rasterizer/backward.py
@@ -90,6 +90,7 @@ def backward_kernel(config: RasterConfig,
       last_point_pixel = thread_index(0)
       T_i = thread_vector(1.0)
       grad_pixel_feature = thread_features(0.0)
+      pixel_feature = thread_features(0.0)
 
       for i, offset in ti.static(pixel_tile):
         pixel = ivec2(offset) + pixel_base
@@ -98,6 +99,7 @@ def backward_kernel(config: RasterConfig,
           last_point_pixel[i] = image_last_valid[pixel.y, pixel.x]
           T_i[i] = 1.0 - image_alpha[pixel.y, pixel.x]
           grad_pixel_feature[i, :] = grad_image_feature[pixel.y, pixel.x]
+          pixel_feature[i, :] = image_feature[pixel.y, pixel.x]
 
       last_point_thread = last_point_pixel.max()
       w_i = thread_features(0.0)
@@ -199,7 +201,8 @@ def backward_kernel(config: RasterConfig,
                   gaussian_alpha)
 
               contribution += vec2(
-                ((feature_diff * weight)**2).sum(),
+                # (((pixel_feature[i, :] - feature) * weight)**2).sum(),
+                (feature_diff**2).sum() * weight,
                 # ((alpha_grad_from_feature)**2).sum()
                 ti.abs(alpha_grad * point_alpha * dp_dmean).sum()
               )

--- a/taichi_splatting/rasterizer/backward.py
+++ b/taichi_splatting/rasterizer/backward.py
@@ -157,7 +157,7 @@ def backward_kernel(config: RasterConfig,
           point_index = end_offset - (group_offset_base + in_group_idx)
 
           if not ti.simt.warp.any_nonzero(ti.u32(0xffffffff), ti.i32(point_index <= last_point_thread)):
-            break
+            continue
 
           # Could factor this out and only compute grad if needed
           # however, it does not seem to make any difference

--- a/taichi_splatting/rasterizer/backward.py
+++ b/taichi_splatting/rasterizer/backward.py
@@ -200,7 +200,7 @@ def backward_kernel(config: RasterConfig,
 
               contribution += vec2(
                 ((feature_diff * weight)**2).sum(),
-                (ti.abs(alpha_grad_from_feature)).sum()
+                (alpha_grad_from_feature**2).sum()
               )
 
           if ti.simt.warp.any_nonzero(ti.u32(0xffffffff), ti.i32(has_grad)):

--- a/taichi_splatting/rasterizer/backward.py
+++ b/taichi_splatting/rasterizer/backward.py
@@ -127,7 +127,7 @@ def backward_kernel(config: RasterConfig,
         # load points and features into block shared memory
         group_offset_base = point_group_id * block_area
 
-        if ti.simt.block.sync_all_nonzero(ti.i32(group_offset_base < last_point_thread)):
+        if ti.simt.block.sync_all_nonzero(ti.i32(end_offset - group_offset_base < last_point_thread)):
           break
 
         # if not ti.simt.warp.any_nonzero(ti.u32(0xffffffff), ti.i32(point_index <= end_offset - group_offset_base)):

--- a/taichi_splatting/rasterizer/backward.py
+++ b/taichi_splatting/rasterizer/backward.py
@@ -200,7 +200,7 @@ def backward_kernel(config: RasterConfig,
 
               contribution += vec2(
                 ((feature_diff * weight)**2).sum(),
-                (ti.abs(alpha_grad_from_feature)).sum()
+                ((alpha_grad_from_feature)**2).sum()
               )
 
           if ti.simt.warp.any_nonzero(ti.u32(0xffffffff), ti.i32(has_grad)):

--- a/taichi_splatting/rasterizer/function.py
+++ b/taichi_splatting/rasterizer/function.py
@@ -47,7 +47,7 @@ def render_function(config:RasterConfig,
       image_alpha = torch.empty(shape, dtype=torch.float32, device=features.device)
       image_last_valid = torch.empty(shape, dtype=torch.int32, device=features.device)
 
-      point_weight = torch.zeros( (gaussians.shape[0], 2) if compute_weight else 0, 
+      point_weight = torch.zeros( (gaussians.shape[0], 2) if compute_weight else (0, 2), 
                                  dtype=torch.float32, device=features.device)
 
       forward(gaussians, features, 
@@ -75,15 +75,15 @@ def render_function(config:RasterConfig,
         grad_gaussians = torch.zeros_like(gaussians)
         grad_features = torch.zeros_like(features)
   
-        with restore_grad(grad_gaussians, grad_features):
+        # with restore_grad(gaussians, features):
 
-          backward(gaussians, features, 
-            ctx.tile_overlap_ranges, ctx.overlap_to_point,
-            image_feature, ctx.image_alpha, ctx.image_last_valid,
-            grad_image_feature.contiguous(),
-            grad_gaussians, grad_features, ctx.point_weight)
+        backward(gaussians, features, 
+          ctx.tile_overlap_ranges, ctx.overlap_to_point,
+          image_feature, ctx.image_alpha, ctx.image_last_valid,
+          grad_image_feature.contiguous(),
+          grad_gaussians, grad_features, ctx.point_weight)
 
-          return grad_gaussians, grad_features, None, None, None, None
+        return grad_gaussians, grad_features, None, None, None, None
   return _module_function
 
 

--- a/taichi_splatting/rasterizer/function.py
+++ b/taichi_splatting/rasterizer/function.py
@@ -62,9 +62,7 @@ def render_function(config:RasterConfig,
       ctx.image_size = image_size
       ctx.point_weight = point_weight
 
-      ctx.mark_non_differentiable(image_alpha, image_last_valid)
-      ctx.mark_non_differentiable(point_weight)
-
+      ctx.mark_non_differentiable(image_alpha, image_last_valid, point_weight, overlap_to_point, tile_overlap_ranges)
       ctx.save_for_backward(gaussians, features, image_feature)
             
       return image_feature, image_alpha, point_weight

--- a/taichi_splatting/rasterizer/function.py
+++ b/taichi_splatting/rasterizer/function.py
@@ -47,7 +47,7 @@ def render_function(config:RasterConfig,
       image_alpha = torch.empty(shape, dtype=torch.float32, device=features.device)
       image_last_valid = torch.empty(shape, dtype=torch.int32, device=features.device)
 
-      point_weight = torch.zeros(gaussians.shape[0] if compute_weight else 0, 
+      point_weight = torch.zeros( (gaussians.shape[0], 2) if compute_weight else 0, 
                                  dtype=torch.float32, device=features.device)
 
       forward(gaussians, features, 

--- a/taichi_splatting/rasterizer/function.py
+++ b/taichi_splatting/rasterizer/function.py
@@ -19,20 +19,20 @@ from beartype import beartype
 RasterOut = NamedTuple('RasterOut', 
     [('image', torch.Tensor), 
      ('image_weight', torch.Tensor),
-     ('point_weight', torch.Tensor) ])
+     ('point_split_heuristics', torch.Tensor) ])
 
 @cache
 def render_function(config:RasterConfig,
                     points_requires_grad:bool,
                     features_requires_grad:bool, 
-                    compute_weight:bool,
+                    compute_split_heuristics:bool,
                     feature_size:int):
   
     
   forward = forward_kernel(config, feature_size=feature_size)
   backward = backward_kernel(config, points_requires_grad,
                              features_requires_grad, 
-                             compute_weight, feature_size)
+                             compute_split_heuristics, feature_size)
 
   class _module_function(torch.autograd.Function):
     @staticmethod
@@ -47,7 +47,7 @@ def render_function(config:RasterConfig,
       image_alpha = torch.empty(shape, dtype=torch.float32, device=features.device)
       image_last_valid = torch.empty(shape, dtype=torch.int32, device=features.device)
 
-      point_weight = torch.zeros( (gaussians.shape[0], 2) if compute_weight else (0, 2), 
+      point_split_heuristics = torch.zeros( (gaussians.shape[0], 2) if compute_split_heuristics else (0, 2), 
                                  dtype=torch.float32, device=features.device)
 
       forward(gaussians, features, 
@@ -60,16 +60,16 @@ def render_function(config:RasterConfig,
       ctx.image_last_valid = image_last_valid
       ctx.image_alpha = image_alpha
       ctx.image_size = image_size
-      ctx.point_weight = point_weight
+      ctx.point_split_heuristics = point_split_heuristics
 
-      ctx.mark_non_differentiable(image_alpha, image_last_valid, point_weight, overlap_to_point, tile_overlap_ranges)
+      ctx.mark_non_differentiable(image_alpha, image_last_valid, point_split_heuristics, overlap_to_point, tile_overlap_ranges)
       ctx.save_for_backward(gaussians, features, image_feature)
             
-      return image_feature, image_alpha, point_weight
+      return image_feature, image_alpha, point_split_heuristics
 
     @staticmethod
     def backward(ctx, grad_image_feature:torch.Tensor, 
-                 grad_alpha:torch.Tensor, grad_point_weight:torch.Tensor):
+                 grad_alpha:torch.Tensor, grad_point_split_heuristics:torch.Tensor):
         gaussians, features, image_feature = ctx.saved_tensors
 
         grad_gaussians = torch.zeros_like(gaussians)
@@ -81,7 +81,7 @@ def render_function(config:RasterConfig,
           ctx.tile_overlap_ranges, ctx.overlap_to_point,
           image_feature, ctx.image_alpha, ctx.image_last_valid,
           grad_image_feature.contiguous(),
-          grad_gaussians, grad_features, ctx.point_weight)
+          grad_gaussians, grad_features, ctx.point_split_heuristics)
 
         return grad_gaussians, grad_features, None, None, None, None
   return _module_function
@@ -94,7 +94,7 @@ def render_function(config:RasterConfig,
 def rasterize_with_tiles(gaussians2d: torch.Tensor, features: torch.Tensor,
               overlap_to_point: torch.Tensor, tile_overlap_ranges: torch.Tensor,
               image_size: Tuple[Integral, Integral], config: RasterConfig,
-              compute_weight:bool=False
+              compute_split_heuristics:bool=False
               ) -> RasterOut:
   """
   Rasterize an image given 2d gaussians, features and tile overlap information.
@@ -111,29 +111,29 @@ def rasterize_with_tiles(gaussians2d: torch.Tensor, features: torch.Tensor,
 
       image_size: (2, ) tuple of ints, (width, height)
       config: Config - configuration parameters for rasterization
-      compute_weight: bool - whether to compute the visibility for each point in the image
+      compute_split_heuristics: bool - whether to compute the visibility for each point in the image
 
     Returns:
       RasterOut - namedtuple with fields:
         image: (H, W, F) torch tensor, where H, W are the image height and width, F is the number of features
         image_weight: (H, W) torch tensor, where H, W are the image height and width
-        point_weight: (N, ) torch tensor, where N is the number of gaussians  
+        point_split_heuristics: (N, ) torch tensor, where N is the number of gaussians  
   """
   _module_function = render_function(config, gaussians2d.requires_grad,
                                       features.requires_grad,
-                                      compute_weight, 
+                                      compute_split_heuristics, 
                                       features.shape[1])
 
-  image, image_weight, point_weight = _module_function.apply(gaussians2d, features, 
+  image, image_weight, point_split_heuristics = _module_function.apply(gaussians2d, features, 
           overlap_to_point, tile_overlap_ranges, 
           image_size)
   
-  return RasterOut(image, image_weight, point_weight)
+  return RasterOut(image, image_weight, point_split_heuristics)
 
 
 def rasterize(gaussians2d:torch.Tensor, encoded_depths:torch.Tensor, 
                           features:torch.Tensor, image_size:Tuple[Integral, Integral],
-                          config:RasterConfig, compute_weight:bool=False) -> RasterOut:
+                          config:RasterConfig, compute_split_heuristics:bool=False) -> RasterOut:
     
     
   """
@@ -146,13 +146,13 @@ def rasterize(gaussians2d:torch.Tensor, encoded_depths:torch.Tensor,
 
       image_size: (2, ) tuple of ints, (width, height)
       config: Config - configuration parameters for rasterization
-      compute_weight: bool - whether to compute the visibility for each point in the image
+      compute_split_heuristics: bool - whether to compute the visibility for each point in the image
 
     Returns:
       RasterOut - namedtuple with fields:
         image: (H, W, F) torch tensor, where H, W are the image height and width, F is the number of features
         image_weight: (H, W) torch tensor, where H, W are the image height and width
-        point_weight: (N, ) torch tensor, where N is the number of gaussians  
+        point_split_heuristics: (N, ) torch tensor, where N is the number of gaussians  
   """
 
   assert gaussians2d.shape[0] == encoded_depths.shape[0] == features.shape[0], \
@@ -164,4 +164,4 @@ def rasterize(gaussians2d:torch.Tensor, encoded_depths:torch.Tensor,
   
   return rasterize_with_tiles(gaussians2d, features, 
     tile_overlap_ranges=tile_overlap_ranges.view(-1, 2), overlap_to_point=overlap_to_point,
-    image_size=image_size, config=config, compute_weight=compute_weight)
+    image_size=image_size, config=config, compute_split_heuristics=compute_split_heuristics)

--- a/taichi_splatting/renderer.py
+++ b/taichi_splatting/renderer.py
@@ -23,7 +23,7 @@ class Rendering:
   depth: Optional[torch.Tensor] = None  # (H, W)
   depth_var: Optional[torch.Tensor] = None # (H, W)
 
-  point_weight: Optional[torch.Tensor] = None  # (N, 1)
+  point_split_heuristics: Optional[torch.Tensor] = None  # (N, 1)
 
   
 
@@ -37,7 +37,7 @@ def render_gaussians(
   use_sh:bool = False,      
   render_depth:bool = False, 
   use_depth16:bool = False,
-  compute_weight:bool = False
+  compute_split_heuristics:bool = False
 ) -> Rendering:
   """
   A complete renderer for 3D gaussians. 
@@ -51,7 +51,7 @@ def render_gaussians(
     use_sh: bool - whether to use spherical harmonics
     render_depth: bool - whether to render depth and depth variance
     use_depth16: bool - whether to use 16 bit depth encoding (otherwise 32 bit)
-    compute_weight: bool - whether to compute the visibility for each point in the image
+    compute_split_heuristics: bool - whether to compute the visibility for each point in the image
   
   Returns:
     images : Rendering - rendered images, with optional depth and depth variance and point weights
@@ -75,7 +75,7 @@ def render_gaussians(
     features = torch.cat([depthvars, features], dim=1)
     
   raster = rasterize(gaussians2d, depth_order, features,
-    image_size=camera_params.image_size, config=config, compute_weight=compute_weight)
+    image_size=camera_params.image_size, config=config, compute_split_heuristics=compute_split_heuristics)
 
   depth, depth_var = None, None
   feature_image = raster.image
@@ -88,7 +88,7 @@ def render_gaussians(
                   image_weight=raster.image_weight, 
                   depth=depth, 
                   depth_var=depth_var, 
-                  point_weight=raster.point_weight if compute_weight else None)
+                  point_split_heuristics=raster.point_split_heuristics if compute_split_heuristics else None)
 
 
 


### PR DESCRIPTION
Compute split heuristics optionally in the backward pass. Based on point_visibility and colour change for pruning and absolute position gradient for splitting.

Make use of it in examples/fit_image_gaussians to implement a new split/prune scheme.

TODO: test in 3D